### PR TITLE
Vuplus dvbaudiosink must run in sync.

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,8 @@ vuplus           : DVBMEDIASINK_CONFIG = "--with-vuplus --with-pcm --with-eac3 -
 Note since 17032015 vuplus added new drivers.
 SRCDATE = "20150317"
 
-For all boxes with drivers from that date or above the --with-vuplus option is not required anymore.
-Then the dvbmediasink config for vuplus must be.
-vuplus           : DVBMEDIASINK_CONFIG = "--with-pcm --with-eac3 --with-amr --with-wmv"
+All old driver vuplus support removed.
+VUPLUS audio must run in sync for vuplus add always option --with-vuplus .
+vuplus           : DVBMEDIASINK_CONFIG = "--with-vuplus --with-pcm --with-eac3 --with-wmv"
+
 

--- a/gstdvbaudiosink.c
+++ b/gstdvbaudiosink.c
@@ -283,9 +283,13 @@ static void gst_dvbaudiosink_init(GstDVBAudioSink *self)
 	self->unlockfd[0] = self->unlockfd[1] = -1;
 	self->rate = 1.0;
 	self->timestamp = GST_CLOCK_TIME_NONE;
-
+#ifdef VUPLUS
+	gst_base_sink_set_sync(GST_BASE_SINK(self), TRUE);
+	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), FALSE);
+#else
 	gst_base_sink_set_sync(GST_BASE_SINK(self), FALSE);
 	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), TRUE);
+#endif
 }
 
 static void gst_dvbaudiosink_dispose(GObject *obj)

--- a/gstdvbvideosink.c
+++ b/gstdvbvideosink.c
@@ -1620,7 +1620,7 @@ static gboolean gst_dvbvideosink_set_caps(GstBaseSink *basesink, GstCaps *caps)
 					gst_buffer_map(gst_value_get_buffer(codec_data), &codecdatamap, GST_MAP_READ);
 					codec_data_pointer = codecdatamap.data;
 					codec_size = codecdatamap.size;
-#if defined(VUPLUS) || defined(DREAMBOX) || defined(DAGS)
+#if defined(DREAMBOX) || defined(DAGS)
 					GstMapInfo map;
 					self->codec_data = gst_buffer_new_and_alloc(8 + codec_size);
 					gst_buffer_map(self->codec_data, &map, GST_MAP_WRITE);
@@ -1637,7 +1637,7 @@ static gboolean gst_dvbvideosink_set_caps(GstBaseSink *basesink, GstCaps *caps)
 					g_free(videocodecdata.data);
 #endif
 					gst_buffer_unmap(gst_value_get_buffer(codec_data), &codecdatamap);
-#if defined(VUPLUS) || defined(DREAMBOX) || defined(DAGS)
+#if defined(DREAMBOX) || defined(DAGS)
 					gst_buffer_unmap(self->codec_data, &map);
 #endif
 				}
@@ -1659,7 +1659,7 @@ static gboolean gst_dvbvideosink_set_caps(GstBaseSink *basesink, GstCaps *caps)
 					if (codec_size > 4) codec_size = 4;
 					gst_structure_get_int(structure, "width", &width);
 					gst_structure_get_int(structure, "height", &height);
-#if defined(VUPLUS) || defined(DREAMBOX) || defined(DAGS)
+#if defined(DREAMBOX) || defined(DAGS)
 					GstMapInfo map;
 					self->codec_data = gst_buffer_new_and_alloc(18 + codec_size);
 					gst_buffer_map(self->codec_data, &map, GST_MAP_WRITE);
@@ -1692,7 +1692,7 @@ static gboolean gst_dvbvideosink_set_caps(GstBaseSink *basesink, GstCaps *caps)
 					g_free(videocodecdata.data);
 #endif
 					gst_buffer_unmap(gst_value_get_buffer(codec_data), &codecdatamap);
-#if defined(VUPLUS) || defined(DREAMBOX) || defined(DAGS)
+#if defined(DREAMBOX) || defined(DAGS)
 					gst_buffer_unmap(self->codec_data, &map);
 #endif
 				}

--- a/gstdvbvideosink.h
+++ b/gstdvbvideosink.h
@@ -66,7 +66,7 @@ typedef struct _GstDVBVideoSinkClass	GstDVBVideoSinkClass;
 typedef struct _GstDVBVideoSinkPrivate	GstDVBVideoSinkPrivate;
 
 typedef enum { CT_MPEG1, CT_MPEG2, CT_H264, CT_DIVX311, CT_DIVX4, CT_MPEG4_PART2, CT_VC1, CT_VC1_SM } t_codec_type;
-#if defined(VUPLUS) || defined(DREAMBOX)
+#if defined(DREAMBOX)
 typedef enum {
 	STREAMTYPE_UNKNOWN = -1,
 	STREAMTYPE_MPEG2 = 0,


### PR DESCRIPTION
  Vuplus audiosink must run in sync.
  If not a lot off movies using aac do not work ok.
  For that the option --with-vuplus must be added back to mediasink config.

```
modified:   README
modified:   gstdvbaudiosink.c
modified:   gstdvbvideosink.c
modified:   gstdvbvideosink.h
```
