### PR TITLE
Set vuduo2 audio back to async

### DIFF
--- a/gstdvbaudiosink.c
+++ b/gstdvbaudiosink.c
@@ -284,8 +284,8 @@ static void gst_dvbaudiosink_init(GstDVBAudioSink *self)
 	self->rate = 1.0;
 	self->timestamp = GST_CLOCK_TIME_NONE;
 #ifdef VUPLUS
-	gst_base_sink_set_sync(GST_BASE_SINK(self), TRUE);
-	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), FALSE);
+	gst_base_sink_set_sync(GST_BASE_SINK(self), FALSE);
+	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), TRUE);
 #else
 	gst_base_sink_set_sync(GST_BASE_SINK(self), FALSE);
 	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), TRUE);


### PR DESCRIPTION
 A recent servicemp3 patch solved some issues
 Vuduo2 seems to work fine agin asyn only.

```
modified:   gstdvbaudiosink.c
```
