### PR TITLE
Set delay on start when using dtsdownmix (work-around)

### DIFF
--- a/gstdvbaudiosink.h
+++ b/gstdvbaudiosink.h
@@ -129,7 +129,7 @@ struct _GstDVBAudioSink
 	gdouble rate;
 	gboolean playing, paused, flushing, unlocking;
 	gboolean pts_written;
-	gboolean flushed, using_dts_downmix;
+	gboolean flushed, using_dts_downmix, first_paused;
 	gint64 lastpts;
 	gint64 timestamp_offset;
 	gint8 ok_to_write;


### PR DESCRIPTION
 Since enigma2 does allow nack the launch off sinks
 before all needed caps are known, we need to delay
 start mkv container movies when using dtsdownmix.

```
modified:   gstdvbaudiosink.c
modified:   gstdvbaudiosink.h
```
