### PR TITLE
Adapted the flush procedure when using dtsdownmix.

### DIFF
--- a/gstdvbvideosink.h
+++ b/gstdvbvideosink.h
@@ -126,7 +126,7 @@ struct _GstDVBVideoSink
 	char saved_fallback_framerate[16];
 
 	gdouble rate;
-	gboolean playing, paused, flushing, unlocking, flushed;
+	gboolean playing, paused, flushing, unlocking, flushed, first_paused;
 	gboolean using_dts_downmix;
 	gboolean pts_written;
 	gint64 lastpts;


### PR DESCRIPTION
 The extra delay when using dts downmix after flsuh only required
 when media is playing. Not in paused state.

```
modified:   gstdvbaudiosink.c
modified:   gstdvbvideosink.c
modified:   gstdvbvideosink.h
```
