### PR TITLE
Openatv dev exp

### DIFF
--- a/common.c
+++ b/common.c
@@ -119,7 +119,22 @@ void gst_sleepus(uint32_t usec)
 	errno = olderrno;
 }
 
-gboolean get_downmix_setting()
+gboolean get_dts_downmix_setting()
+{
+	gboolean ret = FALSE;
+	FILE *f;
+	char buffer[32] = {0};
+	f = fopen("/proc/stb/audio/dts", "r");
+	if (f)
+	{
+		fread(buffer, sizeof(buffer), 1, f);
+		fclose(f);
+	}
+	ret = !strncmp(buffer, "downmix", 7);
+	return ret;
+}
+
+gboolean get_ac3_downmix_setting()
 {
 	gboolean ret = FALSE;
 	FILE *f;
@@ -148,3 +163,19 @@ gboolean get_downmix_ready()
 	ret = !strncmp(buffer, "READY", 5);
 	return ret;
 }
+
+gboolean is_video_ready()
+{
+	gboolean ret = FALSE;
+	FILE *f;
+	char buffer[32] = {0};
+	f = fopen("/tmp/gstdvbvideosink", "r");
+	if (f)
+	{
+		fread(buffer, sizeof(buffer), 1, f);
+		fclose(f);
+	}
+	ret = !strncmp(buffer, "READY", 5);
+	return ret;
+}
+

--- a/common.h
+++ b/common.h
@@ -33,7 +33,8 @@ void pes_set_payload_size(size_t size, unsigned char *pes_header);
 
 void gst_sleepms(uint32_t msec);
 void gst_sleepus(uint32_t usec);
-gboolean get_downmix_setting();
+gboolean get_dts_downmix_setting();
+gboolean get_ac3_downmix_setting();
 gboolean get_downmix_ready();
-
+gboolean is_video_ready();
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -283,6 +283,9 @@ if test `echo "$machine" | cut -b 1-2` == "vu"; then
 	AC_DEFINE([VUPLUS],[1],[build for VUPLUS ])
 	AC_DEFINE([TYPE2],[1],[build bybass TYPE2])
 fi
+if test `echo "$machine" | cut -b 1-4` == "gb73"; then
+	AC_DEFINE([GIGABLUEMIPS],[1],[build for GIGABLUEMIPS ])
+fi
 if [ test "$machine" = "xc7362" || test "$machine" = "xc7346" ]; then
 	AC_DEFINE([TYPE2],[1],[build bybass TYPE2])
 fi

--- a/gstdvbaudiosink.c
+++ b/gstdvbaudiosink.c
@@ -84,7 +84,9 @@ enum
 {
 	PROP_0,
 	PROP_SYNC,
-	PROP_LAST,
+	PROP_ASYNC,
+	PROP_RENDER_DELAY,
+	PROP_LAST
 };
 
 
@@ -139,9 +141,26 @@ static guint gst_dvbaudiosink_signals[LAST_SIGNAL] = { 0 };
 #define LPCMCAPS \
 		"audio/x-private1-lpcm; "
 
+/* DTSCAPS SUPPORTED IN THIS SINK ARE ONLY THAT FROM
+* standard DVD's or blurays or older base DTS 5.1.
+* They all have endianness 4321. p.s. the dvd has his
+* own x-private1-dts cap and they are normally all suported
+* Request to stb manufacturers about the cd audio cap which has
+* a depth of 14(two bits are set to zero to save speakers and you're ears)
+* but also it has 1024 blok-size instead of 512
+* and 4096 frame-size instead of 2012 has been send.
+* Strictly speaking it should work but maybe there are some pess_header
+* changes needed for this cd dts audio wav media type 
+* For now we made the use off cd audio cap not possible.
+* So if You want dts_audio_cd support just install gstreamer1.0-plugins-bad-dtsdec.
+* Only by stb's who have been build with option --with-dtsdownmix do not and may not !!
+* install the plugin from gstreamer.
+*/
+
 #define DTSCAPS \
 		"audio/x-dts, " \
-		"framed =(boolean) true; " \
+		"framed =(boolean) true, " \
+		"endianness = (int) 4321; " \
 		"audio/x-private1-dts, " \
 		"framed =(boolean) true; "
 
@@ -274,6 +293,12 @@ static void gst_dvbaudiosink_class_init(GstDVBAudioSinkClass *self)
 	g_object_class_install_property (gobject_class, PROP_SYNC,
 			g_param_spec_boolean ("sync", "Sync", "Sync on the clock", FALSE,
 					G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+	g_object_class_install_property (gobject_class, PROP_ASYNC,
+			g_param_spec_boolean ("async", "Async", "preroll", FALSE,
+					G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+	g_object_class_install_property (gobject_class, PROP_RENDER_DELAY,
+			g_param_spec_uint64 ("render-delay", "Renderdelay", "Render-delay increase latency",
+				0, G_MAXUINT64, 0, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
 	gstbasesink_class->start = GST_DEBUG_FUNCPTR(gst_dvbaudiosink_start);
 	gstbasesink_class->stop = GST_DEBUG_FUNCPTR(gst_dvbaudiosink_stop);
@@ -308,11 +333,11 @@ static void gst_dvbaudiosink_init(GstDVBAudioSink *self)
 	self->fixed_buffersize = 0;
 	self->fixed_bufferduration = GST_CLOCK_TIME_NONE;
 	self->fixed_buffertimestamp = GST_CLOCK_TIME_NONE;
-	self->aac_adts_header_valid = FALSE;
+	self->aac_adts_header_valid = self->pass_eos = FALSE;
 	self->pesheader_buffer = NULL;
 	self->cache = NULL;
 	self->playing = self->flushing = self->unlocking = self->paused = self->first_paused = FALSE;
-	self->pts_written = self->using_dts_downmix = self->first_paused = FALSE;
+	self->pts_written = self->using_dts_downmix = self->synchronized = self->dts_cd = FALSE;
 	self->lastpts = 0;
 	self->timestamp_offset = 0;
 	self->queue = NULL;
@@ -325,13 +350,27 @@ static void gst_dvbaudiosink_init(GstDVBAudioSink *self)
 #else
 	self->use_set_encoding = FALSE;
 #endif
-#ifdef VUPLUS
-	gst_base_sink_set_sync(GST_BASE_SINK(self), FALSE);
-	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), FALSE);
-#else
-	gst_base_sink_set_sync(GST_BASE_SINK(self), FALSE);
-	gst_base_sink_set_async_enabled(GST_BASE_SINK(self), FALSE);
-#endif
+	if (!strcmp(machine, "hd51") || !strcmp(machine, "gb7356"))
+	{
+		gst_base_sink_set_sync(GST_BASE_SINK(self), TRUE);
+		gst_base_sink_set_async_enabled(GST_BASE_SINK(self), FALSE);
+	}
+	else
+	{
+		gst_base_sink_set_sync(GST_BASE_SINK(self), FALSE);
+		gst_base_sink_set_async_enabled(GST_BASE_SINK(self), FALSE);
+	}
+
+	if (gst_base_sink_get_sync(GST_BASE_SINK(self)))
+	{
+		GST_INFO_OBJECT(self, "sync = TRUE");
+		self->synchronized = TRUE;
+	}
+	else
+	{
+		GST_INFO_OBJECT(self, "sync = FALSE");
+		self->synchronized = FALSE;
+	}
 }
 
 static void gst_dvbaudiosink_dispose(GObject *obj)
@@ -352,29 +391,72 @@ static void gst_dvbaudiosink_set_property (GObject * object, guint prop_id, cons
 
 	switch (prop_id)
 	{
-	/* sink should only work with sync turned off, ignore all attempts to change it */
-	case PROP_SYNC:
-		GST_INFO_OBJECT(self, "ignoring attempt to change 'sync' to '%d'", g_value_get_boolean(value));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
+		/* sink should only work with sync turned off, ignore all attempts to change it *
+		 * looks like no element tries to change this setting so leave it allowed for now *
+		 * subject to changes in future Most stb do support sync settings *
+		 * exception on this are the old dreamboxes and vuplus boxes and maybe some other ol ones */
+		case PROP_SYNC:
+			gst_base_sink_set_sync(GST_BASE_SINK(object), g_value_get_boolean(value));
+			GST_INFO_OBJECT(self, "CHANGE sync setting to sync = %s", g_value_get_boolean(value) ? "TRUE" : "FALSE");
+			if (gst_base_sink_get_sync(GST_BASE_SINK(object)))
+			{
+				GST_INFO_OBJECT(self, "SET gstreamer sync TO TRUE ok");
+				/* the driver should(if the driver support that setting) only synchronize if gstreamer runs sync false mode */
+				if(ioctl(self->fd, AUDIO_SET_AV_SYNC, FALSE) >= 0)
+					GST_INFO_OBJECT(self," AUDIO_SET_AV_SYNC FALSE accepted by driver");
+				else if (self->fd >= 0)
+					GST_ERROR_OBJECT(self,"AUDIO_SET_AV_SYNC FALSE ***NOT*** accepted by driver critical ioctl error");
+				self->synchronized = TRUE;
+			}
+			else
+			{
+				GST_INFO_OBJECT(self, "SET gstreamer sync to FALSE OK");
+				if(ioctl(self->fd, AUDIO_SET_AV_SYNC, TRUE) >= 0)
+					GST_INFO_OBJECT(self," AUDIO_SET_AV_SYNC TRUE accepted by driver");
+				else if (self->fd >= 0)
+					GST_ERROR_OBJECT(self,"AUDIO_SET_AV_SYNC TRUE ***NOT*** accepted by driver critical ioctl error");
+				self->synchronized = FALSE;
+				GST_INFO_OBJECT(self, "SET sync to FALSE OK");
+			}
+			break;
+		case PROP_ASYNC:
+			GST_INFO_OBJECT(self, "ignoring attempt to change 'async' to %s", g_value_get_boolean(value) ? "TRUE" : "FALSE");
+			break;
+		case PROP_RENDER_DELAY:
+			gst_base_sink_set_render_delay(GST_BASE_SINK(object), g_value_get_uint64(value));
+			GST_INFO_OBJECT(self, "Change renderdelay to  = %" G_GUINT64_FORMAT , g_value_get_uint64(value));
+			if (gst_base_sink_get_render_delay(GST_BASE_SINK(object)) == g_value_get_uint64(value))
+				GST_INFO_OBJECT(self, "Renderdelay changed to  %" G_GUINT64_FORMAT , g_value_get_uint64(value));
+			else
+				GST_WARNING_OBJECT(self, "Renderdelay change to  %" G_GUINT64_FORMAT " FAILURE", g_value_get_uint64(value));
+			break;
+		default:
+			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+			break;
 	}
 }
 
 static void gst_dvbaudiosink_get_property (GObject * object, guint prop_id, GValue * value, GParamSpec * pspec)
 {
 	GstDVBAudioSink *self = GST_DVBAUDIOSINK (object);
-	GST_INFO_OBJECT(self, "Get sync property %u", prop_id);
 
 	switch (prop_id)
 	{
-	case PROP_SYNC:
-		g_value_set_boolean(value, gst_base_sink_get_sync(GST_BASE_SINK(object)));
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-		break;
+		case PROP_SYNC:
+			g_value_set_boolean(value, gst_base_sink_get_sync(GST_BASE_SINK(object)));
+			GST_INFO_OBJECT(self, "Requested by other element SYNC VALUE = %s", g_value_get_boolean(value) ? "TRUE" : "FALSE");
+			break;
+		case PROP_ASYNC:
+			g_value_set_boolean(value, gst_base_sink_is_async_enabled(GST_BASE_SINK(object)));
+			GST_INFO_OBJECT(self, "Requested by other element ASYNC VALUE = %s", g_value_get_boolean(value) ? "TRUE" : "FALSE");
+			break;
+		case PROP_RENDER_DELAY:
+			g_value_set_uint64(value, gst_base_sink_get_render_delay(GST_BASE_SINK(object)));
+			GST_INFO_OBJECT(self, "Requested by other element RENDER DELAY = %" G_GUINT64_FORMAT , g_value_get_uint64(value));
+			break;
+		default:
+			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+			break;
 	}
 }
 
@@ -438,19 +520,12 @@ static GstCaps *gst_dvbaudiosink_get_caps(GstBaseSink *basesink, GstCaps *filter
 #endif
 	);
 
-#if defined(HAVE_DTS) && !defined(HAVE_DTSDOWNMIX) && defined(VUPLUS)
-	if (!get_downmix_setting())
-	{
-	gst_caps_append(caps, gst_caps_from_string(DTSCAPS));
-	}
-#endif
-
-#if defined(HAVE_DTS) && !defined(HAVE_DTSDOWNMIX) && !defined(VUPLUS)
+#if defined(HAVE_DTS) && !defined(HAVE_DTSDOWNMIX)
+	/* for the time the static cap has been limited to not be used in case of dts_audio_cd media */
 	gst_caps_append(caps, gst_caps_from_string(DTSCAPS));
 #endif
-
 #ifdef HAVE_DTSDOWNMIX
-	if (!get_downmix_setting())
+	if (!get_ac3_downmix_setting())
 	{
 		gst_caps_append(caps, gst_caps_from_string(DTSCAPS));
 	}
@@ -628,8 +703,19 @@ static gboolean gst_dvbaudiosink_set_caps(GstBaseSink *basesink, GstCaps *caps)
 	}
 	else if (!strcmp(type, "audio/x-dts"))
 	{
+		/* waiting on manufacturers answer about this type of dts but it is already prepared to be used */
+		gint endianness = 0;
+		gboolean str_endianness = gst_structure_get_int(structure, "endianness", &endianness);
+		if(str_endianness && endianness == 1234)
+		{
+			GST_INFO_OBJECT (self, "MEDIA IS DTS_AUDIO_CD");
+			self->dts_cd = TRUE;
+			bypass = AUDIOTYPE_DTS_HD;
+		}
+		else
+			bypass = AUDIOTYPE_DTS;
+
 		GST_INFO_OBJECT(self, "MIMETYPE %s",type);
-		bypass = AUDIOTYPE_DTS;
 	}
 	else if (!strcmp(type, "audio/x-wma"))
 	{
@@ -853,46 +939,64 @@ static gboolean gst_dvbaudiosink_event(GstBaseSink *sink, GstEvent *event)
 		}
 		self->flushed = TRUE;
 		break;
+	case GST_EVENT_STREAM_GROUP_DONE:
+		self->pass_eos = TRUE;
+		break;
 	case GST_EVENT_EOS:
 	{
-		gboolean pass_eos = FALSE;
-		struct pollfd pfd[2];
 #ifdef AUDIO_FLUSH
 		if (self->fd >= 0) ioctl(self->fd, AUDIO_FLUSH, 1/*NONBLOCK*/); //Notify the player that no addionional data will be injected
 #endif
+		struct pollfd pfd[2];
 		pfd[0].fd = self->unlockfd[0];
 		pfd[0].events = POLLIN;
 		pfd[1].fd = self->fd;
 		pfd[1].events = POLLIN;
+
+		int x = 0;
+		int retval = 0;
 		GST_BASE_SINK_PREROLL_UNLOCK(sink);
-		while (1)
+		while (x < 20)
 		{
-			int retval = poll(pfd, 2, 250);
+			retval = poll(pfd, 2, 250);
 			if (retval < 0)
 			{
-				perror("poll in EVENT_EOS");
+				GST_INFO_OBJECT(self,"poll in EVENT_EOS");
 				ret = FALSE;
 				break;
 			}
-
-			if (pfd[0].revents & POLLIN)
+			else if ((pfd[0].revents & POLLIN) == POLLIN)
 			{
-				GST_DEBUG_OBJECT(self, "wait EOS aborted!!\n");
+				GST_INFO_OBJECT(self, "wait EOS aborted!! media is not ended");
 				ret = FALSE;
 				break;
 			}
-
-			if (pfd[1].revents & POLLIN)
+			else if ((pfd[1].revents & POLLIN) == POLLIN)
 			{
-				GST_DEBUG_OBJECT(self, "got buffer empty from driver!\n");
+				GST_INFO_OBJECT(self, "got buffer empty from driver!");
 				break;
 			}
-
-			if (sink->flushing)
+			else if ((pfd[1].revents & POLLPRI) == POLLPRI)
 			{
-				GST_DEBUG_OBJECT(self, "wait EOS flushing!!\n");
+				GST_INFO_OBJECT(self, "got buffer HIPRI empty from driver!");
+				break;
+			}
+			else if (sink->flushing)
+			{
+				GST_INFO_OBJECT(self, "wait EOS flushing!!");
 				ret = FALSE;
 				break;
+			}
+			else
+			{
+				// the buffer empty not always comes actually mostly does not come
+				// on audio only mediastruct pollfd pfd[2]
+				// That causes an eternal loop and gst blocked pipeline
+				// the main cause off the sandkeeper at whild up on media change.
+				// The loop now takes max 5 seconds.
+				x++;
+				if (x >= 20)
+					GST_INFO_OBJECT (self, "Pushing eos to basesink x = %d retval = %d", x, retval);
 			}
 		}
 		GST_BASE_SINK_PREROLL_LOCK(sink);
@@ -901,11 +1005,11 @@ static gboolean gst_dvbaudiosink_event(GstBaseSink *sink, GstEvent *event)
 	case GST_EVENT_SEGMENT:
 	{
 		const GstSegment *segment;
+		gst_event_parse_segment(event, &segment);
 		GstFormat format;
 		gdouble rate;
 		guint64 start, end, pos;
 		gint64 start_dvb;
-		gst_event_parse_segment(event, &segment);
 		format = segment->format;
 		rate = segment->rate;
 		start = segment->start;
@@ -1002,18 +1106,19 @@ static int audio_write(GstDVBAudioSink *self, GstBuffer *buffer, size_t start, s
 			GST_OBJECT_LOCK(self);
 			queue_push(&self->queue, buffer, written, end);
 			GST_OBJECT_UNLOCK(self);
-			GST_DEBUG_OBJECT(self, "pushed %d bytes to queue", len - written);
+			GST_INFO_OBJECT(self, "pushed %d bytes to queue", len - written);
 			break;
 		}
 		else
 		{
-			GST_LOG_OBJECT(self, "going into poll, have %d bytes to write", len - written);
+			GST_TRACE_OBJECT(self, "going into poll, have %d bytes to write", len - written);
 		}
 #if defined(__sh__) && !defined(CHECK_DRAIN)
 		pfd[1].revents = POLLOUT;
 #else
 		if (poll(pfd, 2, -1) < 0)
 		{
+			GST_INFO_OBJECT(self,"poll(pfd, 2, -1) < 0");
 			if (errno == EINTR) continue;
 			retval = -1;
 			break;
@@ -1024,11 +1129,12 @@ static int audio_write(GstDVBAudioSink *self, GstBuffer *buffer, size_t start, s
 			/* read all stop commands */
 			while (1)
 			{
+				GST_INFO_OBJECT(self, "Read all stop commands");
 				gchar command;
 				int res = read(self->unlockfd[0], &command, 1);
 				if (res < 0)
 				{
-					GST_DEBUG_OBJECT(self, "no more commands");
+					GST_INFO_OBJECT(self, "no more commands");
 					/* no more commands */
 					break;
 				}
@@ -1065,12 +1171,12 @@ static int audio_write(GstDVBAudioSink *self, GstBuffer *buffer, size_t start, s
 				else if (wr >= queueend - queuestart)
 				{
 					queue_pop(&self->queue);
-					GST_DEBUG_OBJECT(self, "written %d queue bytes... pop entry", wr);
+					GST_INFO_OBJECT(self, "written %d queue bytes... pop entry", wr);
 				}
 				else
 				{
 					self->queue->start += wr;
-					GST_DEBUG_OBJECT(self, "written %d queue bytes... update offset", wr);
+					GST_INFO_OBJECT(self, "written %d queue bytes... update offset", wr);
 				}
 				GST_OBJECT_UNLOCK(self);
 				continue;
@@ -1174,11 +1280,13 @@ GstFlowReturn gst_dvbaudiosink_push_buffer(GstDVBAudioSink *self, GstBuffer *buf
 
 	if (timestamp != GST_CLOCK_TIME_NONE)
 	{
+		//GST_INFO_OBJECT(self,"timestamp = %" G_GUINT64_FORMAT , (GstClockTime)timestamp);
 		pes_header[7] = 0x80; /* pts */
 		pes_header[8] = 5; /* pts size */
 		pes_header_len += 5;
 		pes_set_pts(timestamp, pes_header);
 	}
+
 
 	if (self->aac_adts_header_valid)
 	{
@@ -1451,7 +1559,7 @@ static gboolean gst_dvbaudiosink_stop(GstBaseSink * basesink)
 {
 	GstDVBAudioSink *self = GST_DVBAUDIOSINK(basesink);
 
-	GST_DEBUG_OBJECT(self, "stop");
+	GST_INFO_OBJECT(self, "stop");
 
 	if (self->fd >= 0)
 	{
@@ -1477,40 +1585,46 @@ static gboolean gst_dvbaudiosink_stop(GstBaseSink * basesink)
 		self->fd = -1;
 	}
 
+	GST_INFO_OBJECT(self, "stop if self->codec_data");
 	if (self->codec_data)
 	{
 		gst_buffer_unref(self->codec_data);
 		self->codec_data = NULL;
 	}
 
+	GST_INFO_OBJECT(self, "stop if self->pesheader_buffer");
 	if (self->pesheader_buffer)
 	{
 		gst_buffer_unref(self->pesheader_buffer);
 		self->pesheader_buffer = NULL;
 	}
-
+	GST_INFO_OBJECT(self, "stop if self->cache");
 	if (self->cache)
 	{
 		gst_buffer_unref(self->cache);
 		self->cache = NULL;
 	}
 
+	GST_INFO_OBJECT(self, "stop if self->queue");
 	while (self->queue)
 	{
 		queue_pop(&self->queue);
 	}
 
+	GST_INFO_OBJECT(self, "stop if self->unlockfd[1] >= 0");
 	/* close write end first */
 	if (self->unlockfd[1] >= 0)
 	{
 		close(self->unlockfd[1]);
 		self->unlockfd[1] = -1;
 	}
+	GST_INFO_OBJECT(self, "stop if self->unlockfd[0] >= 0");
 	if (self->unlockfd[0] >= 0)
 	{
 		close(self->unlockfd[0]);
 		self->unlockfd[0] = -1;
 	}
+	GST_INFO_OBJECT(self, "stop COMPLETED");
 	return TRUE;
 }
 
@@ -1552,6 +1666,21 @@ static GstStateChangeReturn gst_dvbaudiosink_change_state(GstElement *element, G
 		{
 			ioctl(self->fd, AUDIO_SELECT_SOURCE, AUDIO_SOURCE_MEMORY);
 			ioctl(self->fd, AUDIO_PAUSE);
+			/* the driver should(if the driver support that setting) only synchronize if gstreamer runs sync false mode */
+			if(self->synchronized)
+			{
+				if(ioctl(self->fd, AUDIO_SET_AV_SYNC, FALSE) >= 0)
+					GST_INFO_OBJECT(self," AUDIO_SET_AV_SYNC FALSE accepted by driver");
+				else
+					GST_ERROR_OBJECT(self,"AUDIO_SET_AV_SYNC FALSE ***NOT*** accepted by driver critical ioctl error");
+			}
+			else
+			{
+				if(ioctl(self->fd, AUDIO_SET_AV_SYNC, TRUE) >= 0)
+					GST_INFO_OBJECT(self," AUDIO_SET_AV_SYNC TRUE accepted by driver");
+				else
+					GST_ERROR_OBJECT(self,"AUDIO_SET_AV_SYNC TRUE ***NOT*** accepted by driver critical ioctl error");
+			}
 		}
 // dreambox driver issue patch
 #ifdef DREAMBOX

--- a/gstdvbaudiosink.h
+++ b/gstdvbaudiosink.h
@@ -120,7 +120,7 @@ struct _GstDVBAudioSink
 	int unlockfd[2];
 
 	int skip;
-	int bypass;
+	t_audio_type bypass;
 	int fixed_buffersize;
 	GstClockTime fixed_buffertimestamp;
 	GstClockTime fixed_bufferduration;

--- a/gstdvbaudiosink.h
+++ b/gstdvbaudiosink.h
@@ -128,7 +128,7 @@ struct _GstDVBAudioSink
 	GstClockTime timestamp;
 	gdouble rate;
 	gboolean playing, paused, flushing, unlocking;
-	gboolean pts_written;
+	gboolean pts_written, synchronized, pass_eos, dts_cd;
 	gboolean flushed, using_dts_downmix, first_paused;
 	gint64 lastpts;
 	gint64 timestamp_offset;

--- a/gstdvbvideosink.h
+++ b/gstdvbvideosink.h
@@ -56,6 +56,8 @@ G_BEGIN_DECLS
   (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_DVBVIDEOSINK,GstDVBVideoSink))
 #define GST_DVBVIDEOSINK_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_DVBVIDEOSINK,GstDVBVideoSinkClass))
+#define GST_DVBVIDEOSINK_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS ((obj),GST_TYPE_DVBVIDEOSINK,GstDVBVideoSinkClass))
 #define GST_IS_DVBVIDEOSINK(obj) \
   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_DVBVIDEOSINK))
 #define GST_IS_DVBVIDEOSINK_CLASS(klass) \
@@ -151,7 +153,7 @@ struct _GstDVBVideoSink
 	gdouble rate;
 	gboolean playing, paused, flushing, unlocking, flushed, first_paused;
 	gboolean using_dts_downmix;
-	gboolean pts_written;
+	gboolean pts_written, synchronized, pass_eos;
 	gint64 lastpts;
 	gint64 timestamp_offset;
 	gboolean must_send_header, wmv_asf;


### PR DESCRIPTION
Added synchronization of audio on video by gstreamer .
This means 
1) The video will still run always not synchronized since that is impossible due to video vsync issues on high resolution  like for example 1080p.
2) The audio will be synchronized by gstreamer to run synchronized with video. for that is required to disable the driver libav sync by ioctl command "ioctl(self->fd, AUDIO_SET_AV_SYNC, FALSE)"
works in all vuplus boxes gigablue stb's mutant stb's . other stb's needs to be reported. I added and error output if the driver does not support that command. when runing gst in debug mode 4 you can see this message.
the gigablue series and vuplus mips series are running 100 % like this .
the mutant I think this will be for all arm stb's still have problems with media containing very high interleave. especially with wmv asf 3 format that has an interleave off almost 10 seconds which is tremendous. However the vuplus and gigablue driver can cope with it . actually I gues all stb's who do not require the extra pesheader buffer add's see line's in c code gstdvbvideosink between 1216-1225. 

It is possible that some stb's do not support it. please repport . 

to do ":" addapting the servicemp3.cpp player for a better start like it is now is not good . for example using the autoconfig for the sinks off gstreamer may and does lead to critcial errors in some case. in that way that a segfault and stb freeze or full crash may and do occurs sometimes.  That's coming due to a conflict which sometimes arises with the alsa sink on some stb's. 

then emc will need a lot off changings , it tries to use all maps as a playlist which is not ok except maybe for the main recoding movie map there it's ok . Perhaps making specially defined fixed maps which can be treated as playlist , but the other maps just use basic file browsing nothing else. Further the make of a curlist to retain last play position by all audio only media must be removed. It would be better to not using cutlist for last play position but do the resume position like is done by the base player which is used when emc is turned of.

anyway the servicemp3 needs a full overhaul. that will also give a better opportunity to work on integration with emc.  also note for the dm8000 the emc is to heavy takes to much ram. Or at last for the older dm8000 . looks like that some do have more ram . It is not the flash but the avbl ram which is the problem by dm8000.