### PR TITLE
Do not convert get decoder time to nanoseconds.

### DIFF
--- a/gstdvbaudiosink.c
+++ b/gstdvbaudiosink.c
@@ -474,11 +474,12 @@ static void gst_dvbaudiosink_get_property (GObject * object, guint prop_id, GVal
 static gint64 gst_dvbaudiosink_get_decoder_time(GstDVBAudioSink *self)
 {
 	gint64 cur = 0;
+	gint res = -1;
 	if (self->fd < 0 || !self->playing || !self->pts_written)
 		return GST_CLOCK_TIME_NONE;
 
-	ioctl(self->fd, AUDIO_GET_PTS, &cur);
-	if (cur)
+	res = ioctl(self->fd, AUDIO_GET_PTS, &cur);
+	if (cur && res >= 0)
 	{
 		self->lastpts = cur;
 	}
@@ -486,8 +487,9 @@ static gint64 gst_dvbaudiosink_get_decoder_time(GstDVBAudioSink *self)
 	{
 		cur = self->lastpts;
 	}
-	cur *= 11111;
-	cur -= self->timestamp_offset;
+	//cur *= 11111;
+	// timestamp_offset is a gstreamer nanoseconds var
+	cur -= self->timestamp_offset / 11111;
 
 	return cur;
 }

--- a/gstdvbvideosink.c
+++ b/gstdvbvideosink.c
@@ -486,11 +486,12 @@ static void gst_dvbvideosink_get_property (GObject * object, guint prop_id, GVal
 static gint64 gst_dvbvideosink_get_decoder_time(GstDVBVideoSink *self)
 {
 	gint64 cur = 0;
+	gint res = -1;
 	if (self->fd < 0 || !self->playing || !self->pts_written)
 		return GST_CLOCK_TIME_NONE;
 
-	ioctl(self->fd, VIDEO_GET_PTS, &cur);
-	if (cur)
+	res = ioctl(self->fd, VIDEO_GET_PTS, &cur);
+	if (cur && res >= 0)
 	{
 		self->lastpts = cur;
 	}
@@ -498,8 +499,9 @@ static gint64 gst_dvbvideosink_get_decoder_time(GstDVBVideoSink *self)
 	{
 		cur = self->lastpts;
 	}
-	cur *= 11111;
-	cur -= self->timestamp_offset;
+	//cur *= 11111;
+	// timestamp_offset is a gstreamer nanoseconds var
+	cur -= self->timestamp_offset / 11111;
 
 	return cur;
 }


### PR DESCRIPTION
 In e2 and drivers we are working with cycle time:
 90.000 cycles in one seconds.
 gstreamer is using nanoseconds.
 no need to convert to nanoseconds in this function made for e2.
 Since we reconvert this straight ahead back to cycles pts.
 This will avoid unneeded multiply x 11111, to directly divide again by 11111.
 For nothing. This then many time again multiplied x 11111.

NOTE ** this requires also updated e2 with last position procedures updates.

	modified:   gstdvbaudiosink.c
	modified:   gstdvbvideosink.c