### PR TITLE
Change decoder-position time back to nanoseconds.

### DIFF
--- a/gstdvbaudiosink.c
+++ b/gstdvbaudiosink.c
@@ -487,9 +487,9 @@ static gint64 gst_dvbaudiosink_get_decoder_time(GstDVBAudioSink *self)
 	{
 		cur = self->lastpts;
 	}
-	//cur *= 11111;
+	cur *= 11111;
 	// timestamp_offset is a gstreamer nanoseconds var
-	cur -= self->timestamp_offset / 11111;
+	cur -= self->timestamp_offset;
 
 	return cur;
 }

--- a/gstdvbvideosink.c
+++ b/gstdvbvideosink.c
@@ -499,9 +499,9 @@ static gint64 gst_dvbvideosink_get_decoder_time(GstDVBVideoSink *self)
 	{
 		cur = self->lastpts;
 	}
-	//cur *= 11111;
+	cur *= 11111;
 	// timestamp_offset is a gstreamer nanoseconds var
-	cur -= self->timestamp_offset / 11111;
+	cur -= self->timestamp_offset;
 
 	return cur;
 }


### PR DESCRIPTION
 Set the decoder time output back to nanoseconds.
 All the plugins working straight with decoder
 do have to be altered that's to much.
 shame.
 This must also be combined with last eServicemp3update.
 e2 DEV update.

	modified:   gstdvbaudiosink.c
	modified:   gstdvbvideosink.c