### PR TITLE
Adapted h265 cap.

### DIFF
--- a/gstdvbvideosink.c
+++ b/gstdvbvideosink.c
@@ -173,6 +173,8 @@ GST_STATIC_PAD_TEMPLATE (
 #ifdef HAVE_H265
 	"video/x-h265, "
 		VIDEO_CAPS "; "
+	"video/x-h265, "
+		"alignment = (string) nal; "
 #endif
 #ifdef HAVE_H264
 	"video/x-h264, "


### PR DESCRIPTION
 x-h265 cap does not always contain width or height.

	modified:   gstdvbvideosink.c