### PR TITLE
Prevent buffer overflow

### DIFF
--- a/gstdvbvideosink.c
+++ b/gstdvbvideosink.c
@@ -1519,7 +1519,7 @@ static gboolean gst_dvbvideosink_set_caps(GstBaseSink *basesink, GstCaps *caps)
 					{
 						len = (data[cd_pos + 1] << 8) | data[cd_pos + 2];
 						cd_pos += 3;
-						if (cd_len >= (cd_pos+len))
+						if ((cd_len >= (cd_pos+len)) && (tmp_len+len+4 < 2048))
 						{
 							memcpy(tmp+tmp_len, "\x00\x00\x00\x01", 4);
 							tmp_len += 4;
@@ -1595,6 +1595,7 @@ static gboolean gst_dvbvideosink_set_caps(GstBaseSink *basesink, GstCaps *caps)
 							break;
 						}
 						// ignore flags + NAL type (1 byte)
+						int nal_type = data[pos] & 0x3f;
 						int nal_count = data[pos + 1] << 8 | data[pos + 2];
 						pos += 3;
 						for (j = 0; j < nal_count; j++) {
@@ -1608,10 +1609,17 @@ static gboolean gst_dvbvideosink_set_caps(GstBaseSink *basesink, GstCaps *caps)
 								GST_ELEMENT_ERROR (self, STREAM, DECODE, ("Buffer underrun in extra nal (%d >= %ld)", pos + 2 + nal_size, cd_len), (NULL));
 								break;
 							}
-							memcpy(tmp+tmp_len, "\x00\x00\x00\x01", 4);
-							tmp_len += 4;
-							memcpy(tmp + tmp_len, data + pos, nal_size);
-							tmp_len += nal_size;
+							if ((nal_type == 0x20 || nal_type == 0x21 || nal_type == 0x22) && ((tmp_len + 4 + nal_size) < 2048 )) // use only VPS, SPS, PPS nals
+							{
+								memcpy(tmp+tmp_len, "\x00\x00\x00\x01", 4);
+								tmp_len += 4;
+								memcpy(tmp + tmp_len, data + pos, nal_size);
+								tmp_len += nal_size;
+							}
+							else if ((tmp_len + 4 + nal_size) >= 2048)
+							{
+								GST_ELEMENT_WARNING (self, STREAM, DECODE, ("Ignoring nal as tmp buffer is too small tmp_len + nal = %d", tmp_len + 4 + nal_size), (NULL));
+							}
 							pos += nal_size;
 						}
 					}


### PR DESCRIPTION
h265 codec_data can have more than 2500 bytes. tmp char array for the nals
is only 2048 byte long. This caused buffer overflows.
Also only copy needed nals to tmp buffer and ignore all others.